### PR TITLE
@type/@model generation now compatible with the new generation

### DIFF
--- a/src/rune/runtime/base_data_class.py
+++ b/src/rune/runtime/base_data_class.py
@@ -138,8 +138,8 @@ class BaseDataClass(BaseModel, ComplexTypeMetaDataMixin):
                                     raise_exc=raise_validation_errors)
 
             root_meta = self.__dict__.setdefault(ROOT_CONTAINER, {})
-            root_meta['@type'] = self.__class__.__module__
-            root_meta['@model'] = self.__class__.__module__.split(
+            root_meta['@type'] = self._FQRTN
+            root_meta['@model'] = self._FQRTN.split(
                 '.', maxsplit=1)[0]
             root_meta['@version'] = self.get_model_version()
 

--- a/src/rune/runtime/metadata.py
+++ b/src/rune/runtime/metadata.py
@@ -350,7 +350,8 @@ class ComplexTypeMetaDataMixin(BaseMetaDataMixin):
         res = obj.serialise_meta()
         res |= obj.model_dump(exclude_unset=True, exclude_defaults=True)
         if cls != obj.__class__:
-            res = {'@type': obj.__class__.__module__} | res
+            # pylint: disable=protected-access
+            res = {'@type': obj._FQRTN} | res
         return res
 
     @classmethod

--- a/test/serializer-round-trip/test_extension.py
+++ b/test/serializer-round-trip/test_extension.py
@@ -95,11 +95,11 @@ def test_temp():
     {
         "nodeRef" : {
             "typeA" : {
-            "fieldA" : "foo",
-            "@key" : "someKey1x"
+                "fieldA" : "foo",
+                "@key" : "someKey1x"
             },
             "aReference" : {
-            "@ref" : "someKey1x"
+                "@ref" : "someKey1x"
             }
         }
     }


### PR DESCRIPTION
Runtime change to catch-up with the new generation.