### PR TITLE
Disable metadata verification for PyPI publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,4 +43,5 @@ jobs:
         with:
           # This tells the action to upload everything in dist/, 
           # including the signatures, but skip internal 'checks' on them.
+          verify-metadata: false
           packages-dir: dist/


### PR DESCRIPTION
Metadata is checked by the twine step before signing.