### PR TITLE
Add pytest configuration to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,8 @@ where = ["src"]
 
 [tool.setuptools_scm]
 version_file = "src/rune/runtime/version.py"
+
+[tool.pytest.ini_options]
+pythonpath = [
+    ".",
+]


### PR DESCRIPTION
Provide pytest with the path of the workspace so that the test imports work (the test directory has __init__.py and is assumed a module by pytest)