### PR TITLE
Support Rune meta type syntax

### DIFF
--- a/src/rune/runtime/base_data_class.py
+++ b/src/rune/runtime/base_data_class.py
@@ -11,7 +11,7 @@ from pydantic import (BaseModel, ValidationError, ConfigDict, model_serializer,
 from pydantic.main import IncEx
 from rune.runtime.conditions import ConditionViolationError
 from rune.runtime.conditions import get_conditions
-from rune.runtime.metadata import (ComplexTypeMetaDataMixin, Reference,
+from rune.runtime.metadata import (REFS_CONTAINER, ComplexTypeMetaDataMixin, Reference,
                                    UnresolvedReference, BaseMetaDataMixin,
                                    _EnumWrapper, RUNE_OBJ_MAPS)
 
@@ -122,6 +122,11 @@ class BaseDataClass(BaseModel, ComplexTypeMetaDataMixin):
         obj = handler(data)
         obj._init_rune_parent()  # pylint: disable=protected-access
         obj.resolve_references(ignore_dangling=True, recurse=False)
+        # transfer refs that were established on the original before 
+        # re-validation wiped them
+        if isinstance(data, BaseDataClass) and not obj._get_rune_refs_container():
+            if original_refs := data._get_rune_refs_container():
+                obj.__dict__[REFS_CONTAINER] = dict(original_refs)
         return obj
 
     def _init_rune_parent(self):

--- a/src/rune/runtime/metadata.py
+++ b/src/rune/runtime/metadata.py
@@ -251,6 +251,13 @@ class BaseMetaDataMixin:
         '''the parent object'''
         return self.__dict__.get(PARENT_PROP)
 
+    def resolve_ref(self, property_name: str) -> Any:
+        ''' if the property exists and it is a reference, return the reference,
+            otherwise return None
+        '''
+        refs = self._get_rune_refs_container()
+        return refs.get(property_name, [None])[0]
+
     def _get_meta_container(self) -> dict[str, Any]:
         return self.__dict__.get(META_CONTAINER, {})
 

--- a/src/rune/runtime/metadata.py
+++ b/src/rune/runtime/metadata.py
@@ -251,7 +251,7 @@ class BaseMetaDataMixin:
         '''the parent object'''
         return self.__dict__.get(PARENT_PROP)
 
-    def resolve_ref(self, property_name: str) -> Any:
+    def resolve_ref_key(self, property_name: str) -> Any:
         ''' if the property exists and it is a reference, return the reference,
             otherwise return None
         '''

--- a/test/test_keys_and_references.py
+++ b/test/test_keys_and_references.py
@@ -275,6 +275,18 @@ def test_ref_ext_assign_2():
     assert id(model.loan) == id(model.repayment)
 
 
+def test_resolve_ref_returns_reference_key():
+    '''resolve_ref returns the stored reference key'''
+    model = DummyLoan2(loan=CashFlow(currency='EUR', amount=100),
+                       repayment=CashFlow(currency='EUR', amount=101))
+    assert model.resolve_ref('repayment') is None
+
+    model.repayment = Reference(model.loan, 'loan-ref-key')
+
+    assert model.resolve_ref('repayment') == 'loan-ref-key'
+    assert model.resolve_ref('loan') is None
+
+
 def test_ref_ext_assign_with_cow_wrapped_parent():
     '''test external-key lookup through a COW-wrapped parent'''
     model = DummyLoan2(loan=CashFlow(currency='EUR', amount=100),

--- a/test/test_keys_and_references.py
+++ b/test/test_keys_and_references.py
@@ -275,16 +275,16 @@ def test_ref_ext_assign_2():
     assert id(model.loan) == id(model.repayment)
 
 
-def test_resolve_ref_returns_reference_key():
+def test_resolve_ref_key_returns_reference_key():
     '''resolve_ref returns the stored reference key'''
     model = DummyLoan2(loan=CashFlow(currency='EUR', amount=100),
                        repayment=CashFlow(currency='EUR', amount=101))
-    assert model.resolve_ref('repayment') is None
+    assert model.resolve_ref_key('repayment') is None
 
     model.repayment = Reference(model.loan, 'loan-ref-key')
 
-    assert model.resolve_ref('repayment') == 'loan-ref-key'
-    assert model.resolve_ref('loan') is None
+    assert model.resolve_ref_key('repayment') == 'loan-ref-key'
+    assert model.resolve_ref_key('loan') is None
 
 
 def test_ref_ext_assign_with_cow_wrapped_parent():


### PR DESCRIPTION
Add support for Rune's metatype syntax which enables naming of metadata types for use in expressions such as filtering by whether an eject is a reference.